### PR TITLE
Feature - Paulus 2 exception compatibility

### DIFF
--- a/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
@@ -168,7 +168,7 @@ class Api extends AbstractController
      *
      * @param mixed $result_data
      * @access public
-     * @return mixed
+     * @return ControllerInterface
      */
     public function handleResult($result_data)
     {
@@ -219,9 +219,9 @@ class Api extends AbstractController
      * Handle an exception thrown during the callback
      * execution of the current controller
      *
-     * @param Exception $e  The actual exception object itself
+     * @param Exception $exception  The actual exception object itself
      * @access public
-     * @return mixed
+     * @return ControllerInterface
      */
     public function handleException(Exception $exception)
     {

--- a/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
@@ -230,43 +230,24 @@ class Api extends AbstractController
             // Grab our validation errors from our exception
             $error_data = $exception->get_errors(true);
 
-            $verbose_exception = InvalidParameters::create(null, null, $exception);
-            $verbose_exception->setMoreInfo($error_data);
-
-            // Handle the rest with our parent. :)
-            parent::handleException(
-                $verbose_exception
-            );
+            $exception = InvalidParameters::create(null, null, $exception);
+            $exception->setMoreInfo($error_data);
 
         } elseif ($exception instanceof InvalidDataModelException) {
             // Grab our validation errors from our exception
             $error_data = $exception->getErrors();
 
-            $verbose_exception = InvalidParameters::create(null, null, $exception);
-            $verbose_exception->setMoreInfo($error_data);
-
-            // Handle the rest with our parent. :)
-            parent::handleException(
-                $verbose_exception
-            );
+            $exception = InvalidParameters::create(null, null, $exception);
+            $exception->setMoreInfo($error_data);
 
         } elseif ($exception instanceof RedisConnectionException) {
-            // Let's handle the exception gracefully
-            parent::handleException(
-                DatabaseConnectionException::create(null, null, $exception)
-            );
+            $exception = DatabaseConnectionException::create(null, null, $exception);
 
         } elseif ($exception instanceof DatabaseException) {
-            // Let's handle the exception gracefully
-            parent::handleException(
-                DatabaseConnectionException::create(null, null, $exception)
-            );
+            $exception = DatabaseConnectionException::create(null, null, $exception);
 
         } elseif ($exception instanceof RecordNotFound) {
-            // Let's handle the exception gracefully
-            parent::handleException(
-                ObjectNotFound::create(null, null, $exception)
-            );
+            $exception = ObjectNotFound::create(null, null, $exception);
 
         } elseif ($exception instanceof HTTPBasicUnauthorized) {
             // Grab our "realm"
@@ -274,9 +255,6 @@ class Api extends AbstractController
 
             // Tell the device/consumer that they must pass auth data
             $this->response->header('WWW-Authenticate', 'Basic realm="' . $realm . '"');
-
-            // Handle the rest with our parent. :)
-            parent::handleException($exception);
 
         }
 

--- a/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Controller/Api.php
@@ -230,7 +230,7 @@ class Api extends AbstractController
             // Grab our validation errors from our exception
             $error_data = $exception->get_errors(true);
 
-            $verbose_exception = new InvalidParameters();
+            $verbose_exception = InvalidParameters::create(null, null, $exception);
             $verbose_exception->setMoreInfo($error_data);
 
             // Handle the rest with our parent. :)
@@ -242,7 +242,7 @@ class Api extends AbstractController
             // Grab our validation errors from our exception
             $error_data = $exception->getErrors();
 
-            $verbose_exception = new InvalidParameters();
+            $verbose_exception = InvalidParameters::create(null, null, $exception);
             $verbose_exception->setMoreInfo($error_data);
 
             // Handle the rest with our parent. :)
@@ -253,19 +253,19 @@ class Api extends AbstractController
         } elseif ($exception instanceof RedisConnectionException) {
             // Let's handle the exception gracefully
             parent::handleException(
-                new DatabaseConnectionException()
+                DatabaseConnectionException::create(null, null, $exception)
             );
 
         } elseif ($exception instanceof DatabaseException) {
             // Let's handle the exception gracefully
             parent::handleException(
-                new DatabaseConnectionException()
+                DatabaseConnectionException::create(null, null, $exception)
             );
 
         } elseif ($exception instanceof RecordNotFound) {
             // Let's handle the exception gracefully
             parent::handleException(
-                new ObjectNotFound()
+                ObjectNotFound::create(null, null, $exception)
             );
 
         } elseif ($exception instanceof HTTPBasicUnauthorized) {

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/AuthenticationRequired.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/AuthenticationRequired.php
@@ -22,10 +22,26 @@ class AuthenticationRequired extends Unauthorized
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'A required access token was not sent';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'A required access token was not sent';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/BadCredentials.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/BadCredentials.php
@@ -24,10 +24,26 @@ class BadCredentials extends Unauthorized
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Please check your credentials and try again';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'Please check your credentials and try again';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/DatabaseConnectionException.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/DatabaseConnectionException.php
@@ -24,10 +24,26 @@ class DatabaseConnectionException extends BadGateway
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'There was an error connecting to or retrieving from the Database';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'There was an error connecting to or retrieving from the Database';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/HTTPBasicUnauthorized.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/HTTPBasicUnauthorized.php
@@ -24,10 +24,26 @@ class HTTPBasicUnauthorized extends Unauthorized
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = '';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = '';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/InvalidDataModelException.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/InvalidDataModelException.php
@@ -37,18 +37,25 @@ class InvalidDataModelException extends UnexpectedValueException
      */
     const DEFAULT_ERROR_KEY = 'generic';
 
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'The data model is invalid';
+
 
     /**
      * Properties
      */
 
     /**
-     * Default exception message
+     * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'The data model is invalid';
+    protected $message = self::DEFAULT_MESSAGE;
 
     /**
      * Errors array

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/NotImplementedException.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/NotImplementedException.php
@@ -20,10 +20,26 @@ class NotImplementedException extends UnsupportedMethodException
 {
 
     /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Method or function is not (yet) implemented';
+
+
+    /**
+     * Properties
+     */
+
+    /**
      * The exception message
      *
      * @var string
      * @access protected
      */
-    protected $message = 'Method or function is not (yet) implemented';
+    protected $message = self::DEFAULT_MESSAGE;
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/UnsupportedMethodException.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/UnsupportedMethodException.php
@@ -22,12 +22,27 @@ class UnsupportedMethodException extends LogicException
 {
 
     /**
-     * The exception and response code
-     *
-     * @var int
-     * @access protected
+     * Constants
      */
-    protected $code = 500;
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Unsupported method call';
+
+    /**
+     * The default exception code
+     *
+     * @const int
+     */
+    const DEFAULT_CODE = 500;
+
+
+    /**
+     * Properties
+     */
 
     /**
      * The exception message
@@ -35,5 +50,13 @@ class UnsupportedMethodException extends LogicException
      * @var string
      * @access protected
      */
-    protected $message = 'Unsupported method call';
+    protected $message = self::DEFAULT_MESSAGE;
+
+    /**
+     * The exception and response code
+     *
+     * @var int
+     * @access protected
+     */
+    protected $code = self::DEFAULT_CODE;
 }


### PR DESCRIPTION
This PR improves the Paulus exception handling and is a necessity for the exception changes in Rican7/Paulus#5

Other than the obvious constant additions for compatibility, this PR also changes how the base `Api` controller class handles exceptions in the `handleException()` method. Previously this method was passing the exception to the parent handler, but was never halting afterwards. This caused a condition that allowed the exception to be handled multiple times (once in the `if` block and once in the last default expression). This was causing a number of problems, including throwing eventual fatal errors and Paulus attempting to send a response more than once (oops!).
