### PR TITLE
Feature - Paulus 2 exception handler

### DIFF
--- a/src/OneMightyRoar/PHP_Paulus_Components/ApiApp.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/ApiApp.php
@@ -56,10 +56,8 @@ class ApiApp extends BasicApp
         parent::__construct($base_path, $app_namespace, $config, $router, $locator, $logger);
 
         // Set our default response
-        if (null === $this->default_response) {
-            $this->setDefaultResponse(
-                (new ApiResponse())->unlock()
-            );
-        }
+        $this->setDefaultResponse(
+            (new ApiResponse())->unlock()
+        );
     }
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/ApiApp.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/ApiApp.php
@@ -59,5 +59,10 @@ class ApiApp extends BasicApp
         $this->setDefaultResponse(
             (new ApiResponse())->unlock()
         );
+
+        // Set our exception handler's response object
+        $this->exception_handler->setResponse(
+            (new ApiResponse())->unlock()
+        );
     }
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/InternalApplicationException.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/Exception/Http/InternalApplicationException.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHP-Paulus-Components
+ *
+ * Components to enhance Paulus projects to enable quicker, more structured REST API's
+ *
+ * @copyright   2013 One Mighty Roar
+ * @link        http://onemightyroar.com
+ */
+
+namespace OneMightyRoar\PHP_Paulus_Components\Exception\Http;
+
+use Paulus\Exception\Http\Standard\InternalServerError;
+
+/**
+ * InternalApplicationException
+ *
+ * Exception representing a fatal internal application error
+ *
+ * @uses Paulus\Exception\Http\Standard\InternalServerError
+ * @package OneMightyRoar\PHP_Paulus_Components\Exception\Http
+ */
+class InternalApplicationException extends InternalServerError
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * The default exception message
+     *
+     * @const string
+     */
+    const DEFAULT_MESSAGE = 'Something went wrong. Please try again later.';
+
+
+    /**
+     * Properties
+     */
+
+    /**
+     * The exception message
+     *
+     * @var string
+     * @access protected
+     */
+    protected $message = self::DEFAULT_MESSAGE;
+}


### PR DESCRIPTION
This PR is a follow up to the changes introduced in Rican7/Paulus#6.

This PR simply updates our `ApiApp` constructor to properly set the exception handler response and creates a new exception class for a "nicer" message during internal server errors.
