### PR TITLE
Feature - Paulus Composer compatibility upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
    ],
    "require": {
       "php": ">=5.4.0",
-      "klein/klein": "dev-master",
-      "paulus/paulus": "dev-release/2.0.0"
+      "klein/klein": "~2.1.0",
+      "paulus/paulus": "~2.0.0-dev"
    },
    "require-dev": {
       "phpunit/phpunit": "3.7.x",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
       "paulus/paulus": "~2.0.0-dev"
    },
    "require-dev": {
-      "phpunit/phpunit": "3.7.x",
-      "phpunit/php-code-coverage": "1.2.x",
-      "squizlabs/php_codesniffer": "1.4.6"
+      "phpunit/phpunit": "~3.7",
+      "phpunit/php-code-coverage": "~1.2",
+      "squizlabs/php_codesniffer": "~1.5"
    },
    "suggest": {
       "onemightyroar/php-activerecord-components": "~1.0    For easy integration with a php-activerecord project"

--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,36 @@
 {
-   "name": "onemightyroar/php-paulus-components",
-   "description": "Components to enhance Paulus projects to enable quicker, more structured REST API's",
-   "type": "library",
-   "keywords": ["paulus", "rest", "api", "bootstrap"],
-   "homepage": "http://onemightyroar.com/",
-   "license": "MIT",
-   "authors": [
-      {
-         "name": "Trevor N. Suarez",
-         "email": "trevor@onemightyroar.com",
-         "homepage": "http://about.me/tnsuarez"
-      },
-      {
-         "name": "Brian C. Muse",
-         "email": "brian@onemightyroar.com",
-         "homepage": "http://brianmuse.com/"
-      }
-   ],
-   "require": {
-      "php": ">=5.4.0",
-      "klein/klein": "~2.1.0",
-      "paulus/paulus": "~2.0.0-dev"
-   },
-   "require-dev": {
-      "phpunit/phpunit": "~3.7",
-      "phpunit/php-code-coverage": "~1.2",
-      "squizlabs/php_codesniffer": "~1.5"
-   },
-   "suggest": {
-      "onemightyroar/php-activerecord-components": "~1.0    For easy integration with a php-activerecord project"
-   },
-   "autoload": {
-      "psr-0": { "OneMightyRoar\\PHP_Paulus_Components\\": "src/" }
-   }
+  "name": "onemightyroar/php-paulus-components",
+  "description": "Components to enhance Paulus projects to enable quicker, more structured REST API's",
+  "type": "library",
+  "keywords": ["paulus", "rest", "api", "bootstrap"],
+  "homepage": "http://onemightyroar.com/",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Trevor N. Suarez",
+      "email": "trevor@onemightyroar.com",
+      "homepage": "http://about.me/tnsuarez"
+    },
+    {
+      "name": "Brian C. Muse",
+      "email": "brian@onemightyroar.com",
+      "homepage": "http://brianmuse.com/"
+    }
+  ],
+  "require": {
+    "php": ">=5.4.0",
+    "klein/klein": "~2.1.0",
+    "paulus/paulus": "~2.0.0-dev"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~3.7",
+    "phpunit/php-code-coverage": "~1.2",
+    "squizlabs/php_codesniffer": "~1.5"
+  },
+  "suggest": {
+    "onemightyroar/php-activerecord-components": "~1.0    For easy integration with a php-activerecord project"
+  },
+  "autoload": {
+    "psr-0": { "OneMightyRoar\\PHP_Paulus_Components\\": "src/" }
+  }
 }


### PR DESCRIPTION
This PR is a follow up to Rican7/Paulus#10 and Rican7/Paulus#11 to ensure compatibility with our new version constraints and aliasing.

V-simple.

Since I've re-indented the composer.json file (it was 3-spaces... wat), here's a convenient link to look at the file diff without whitespace changes: https://github.com/onemightyroar/PHP-Paulus-Components/pull/4/files?w=1
