### PR TITLE
Bugfix - Default value handling in `prepare()`

### DIFF
--- a/src/OneMightyRoar/PHP_Paulus_Components/BasicApp.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/BasicApp.php
@@ -158,11 +158,10 @@ class BasicApp extends Paulus
     public function prepare($auto_load_routes = true, RouteLoader $route_loader = null)
     {
         // Change our defaults
-        $auto_load_routes = (null === $auto_load_routes) ? true : $auto_load_routes;
         $route_loader = $route_loader
             ?: RouteLoaderFactory::buildByDirectoryInferring($this->router, $this->app_base_path);
 
         // Call our parent
-        return parent::prepare($auto_load_routes, $route_loader);
+        return parent::prepare((bool) $auto_load_routes, $route_loader);
     }
 }

--- a/src/OneMightyRoar/PHP_Paulus_Components/BasicApp.php
+++ b/src/OneMightyRoar/PHP_Paulus_Components/BasicApp.php
@@ -155,10 +155,10 @@ class BasicApp extends Paulus
      * @access public
      * @return BasicApp
      */
-    public function prepare($auto_load_routes = null, RouteLoader $route_loader = null)
+    public function prepare($auto_load_routes = true, RouteLoader $route_loader = null)
     {
         // Change our defaults
-        $auto_load_routes = (null === $auto_load_routes) ? true : false;
+        $auto_load_routes = (null === $auto_load_routes) ? true : $auto_load_routes;
         $route_loader = $route_loader
             ?: RouteLoaderFactory::buildByDirectoryInferring($this->router, $this->app_base_path);
 


### PR DESCRIPTION
This bug was caught when attempting to provide a value override when customizing the `prepare()` method's process upstream in an app. Unless a `null` value was passed to the first argument (which is actually a boolean argument...) the value would always be false. Whoops!

This PR fixes the default value to actually be a boolean, and instead allow for the coercion of a `null` value to a sane default instead of always overwriting the original value.
